### PR TITLE
GDK Create Bitmap issue.

### DIFF
--- a/Splat/Gdk/Bitmaps.cs
+++ b/Splat/Gdk/Bitmaps.cs
@@ -27,7 +27,7 @@ namespace Splat
 
         public IBitmap Create(float width, float height)
         {
-            return new PixbufBitmap(new Pixbuf(Colorspace.Rgb, true, 32, (int)width, (int)height));
+            return new PixbufBitmap(new Pixbuf(Colorspace.Rgb, true, 8, (int)width, (int)height));
         }
     }
 


### PR DESCRIPTION
GDK Pixbuf uses gdk_pixbuf_new() of which the bits_per_sample are
defined (per channel), not the full BPP. Since a sample is per channel, an internal
assertion is created if it is not set to 8.

See here -
https://developer.gnome.org/gdk-pixbuf/2.22/gdk-pixbuf-creating.html#gdk
-pixbuf-new
